### PR TITLE
Update ioctls in guest applications

### DIFF
--- a/src/get-report.c
+++ b/src/get-report.c
@@ -257,7 +257,7 @@ int get_report(const uint8_t *data, size_t data_size,
 	int fd = -1;
 	struct snp_report_req req;
 	struct snp_report_resp resp;
-	struct snp_user_guest_request guest_req;
+	struct snp_guest_request_ioctl guest_req;
 	struct msg_report_resp *report_resp = (struct msg_report_resp *)&resp.data;
 
 	if (!report) {
@@ -272,13 +272,13 @@ int get_report(const uint8_t *data, size_t data_size,
 
 	/* Initialize data structures */
 	memset(&req, 0, sizeof(req));
-	req.msg_version = 1;
 	if (data)
 		memcpy(&req.user_data, data, data_size);
 
 	memset(&resp, 0, sizeof(resp));
 
 	memset(&guest_req, 0, sizeof(guest_req));
+	guest_req.msg_version = 1;
 	guest_req.req_data = (__u64) &req;
 	guest_req.resp_data = (__u64) &resp;
 
@@ -334,7 +334,7 @@ int get_extended_report(const uint8_t *data, size_t data_size,
 	int fd = -1;
 	struct snp_ext_report_req req;
 	struct snp_report_resp resp;
-	struct snp_user_guest_request guest_req;
+	struct snp_guest_request_ioctl guest_req;
 	struct msg_report_resp *report_resp = (struct msg_report_resp *)&resp.data;
 	struct cert_table certs_data;
 	size_t page_size = 0, nr_pages = 0;
@@ -351,7 +351,6 @@ int get_extended_report(const uint8_t *data, size_t data_size,
 
 	/* Initialize data structures */
 	memset(&req, 0, sizeof(req));
-	req.data.msg_version = 1;
 #if 1
 	req.certs_address = (__u64)-1;	/* Invalid, non-zero address */
 #endif
@@ -361,6 +360,7 @@ int get_extended_report(const uint8_t *data, size_t data_size,
 	memset(&resp, 0, sizeof(resp));
 
 	memset(&guest_req, 0, sizeof(guest_req));
+	guest_req.msg_version = 1;
 	guest_req.req_data = (__u64) &req;
 	guest_req.resp_data = (__u64) &resp;
 

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -252,7 +252,7 @@ int request_key(struct options *options, uint8_t *key, size_t size)
 	int fd = -1;
 	struct snp_derived_key_req req;
 	struct snp_derived_key_resp resp;
-	struct snp_user_guest_request guest_req;
+	struct snp_guest_request_ioctl guest_req;
 	struct msg_key_resp *key_resp = (struct msg_key_resp *)&resp.data;
 
 	if (!options || !key || size < sizeof(key_resp->derived_key)) {
@@ -262,16 +262,16 @@ int request_key(struct options *options, uint8_t *key, size_t size)
 
 	/* Initialize data structures */
 	memset(&req, 0, sizeof(req));
-	req.msg_version = 1;
-	req.data.root_key_select = options->do_root_key ? MSG_KEY_REQ_ROOT_KEY_SELECT_MASK
+	req.root_key_select = options->do_root_key ? MSG_KEY_REQ_ROOT_KEY_SELECT_MASK
 							: 0;
-	req.data.guest_field_select = options->fields;
-	req.data.guest_svn = options->svn;
-	memcpy(&req.data.tcb_version, &options->tcb, sizeof(req.data.tcb_version));
+	req.guest_field_select = options->fields;
+	req.guest_svn = options->svn;
+	memcpy(&req.tcb_version, &options->tcb, sizeof(req.tcb_version));
 
 	memset(&resp, 0, sizeof(resp));
 
 	memset(&guest_req, 0, sizeof(guest_req));
+	guest_req.msg_version = 1;
 	guest_req.req_data = (__u64) &req;
 	guest_req.resp_data = (__u64) &resp;
 


### PR DESCRIPTION
Some applications fail to compile when using the newer kernel and header files from `sev-snp-v10` branch of the [AMDESE/linux](https://github.com/AMDESE/linux/) repository, which is also listed as the current stable guest kernel [here](https://github.com/AMDESE/AMDSEV/blob/sev-snp-devel/stable-commits) .
Both the `sev-guest-get-report` and `sev-guest-kdf` binaries fail to build because they use a different (outdated) ioctl interface to communicate with the sev-guest driver.

This pull request updates both programs to use the ioctl interface described in the `sev-snp-v10` branch. As a side note, I could not get the `sev-host-set-cert-chain` binaries to build as the `SEV_SET_EXT_CONFIG` command is not implemented in `sev-snp-v10`.