### PR TITLE
Allow compiling against openssl1.1

### DIFF
--- a/src/set-cert-chain.c
+++ b/src/set-cert-chain.c
@@ -15,6 +15,16 @@
 #include <linux/psp-sev.h>
 #include <cert-table.h>
 
+#define  SNP_SET_EXT_CONFIG 55
+#define  SNP_GET_EXT_CONFIG 56
+
+
+struct sev_user_data_ext_snp_config {
+	uint64_t config_address;		/* In */
+	uint64_t certs_address;		/* In */
+	uint32_t certs_len;		/* In */
+};
+
 #ifndef PROG_NAME
 #define PROG_NAME	"sev-host-set-cert-chain"
 #endif


### PR DESCRIPTION
Add some conditional compilation to fall back to older openssl API in order to make things workable with openssl1.1